### PR TITLE
Now able to restore local video 

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -531,8 +531,8 @@ export default (ComposedComponent) => {
       this.setState({ isSharingScreen: true }, () => {
         console.log('----> screenShareConfig: ' + JSON.stringify(screenShareConfig));
         this.state.irisRtcSession.switchStream(this.state.irisRtcStream, screenShareConfig);
-        console.log(this.state.session.session.peerconnection);
-        console.log(this.state.session.session.connection.xmpp.getSessions());
+        console.log("Peer connection: ", this.state.irisRtcSession.peerconnection);
+        console.log("Connection.xmpp: ", this.state.irisRtcSession.connection.xmpp);
       });
     }
 
@@ -565,7 +565,7 @@ export default (ComposedComponent) => {
           };
 
           this.setState({ isSharingScreen: false }, () => {
-            this.state.session.switchStream(streamConfig);
+            this.state.irisRtcSession.switchStream(this.state.irisRtcStream, screenShareConfig);
           });
         })
         .catch((error) => console.error('ERROR: ' + error));

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -546,7 +546,8 @@ export default (ComposedComponent) => {
           const screenshareConnection = localConnectionList.pop();
           // stop the tracks so that the browser knows we're done sharing the screen
           // if we don't do this, chrome's screenshare bar won't close
-          screenshareConnection.video.track.stream.getTracks().map((track) => {
+          //screenshareConnection.video.track.stream.getTracks().map((track) => {
+          screenshareConnection.getVideoTracks().map(function (track) {
             if (track.stop) {
               track.stop();
             }
@@ -565,7 +566,7 @@ export default (ComposedComponent) => {
           };
 
           this.setState({ isSharingScreen: false }, () => {
-            this.state.irisRtcSession.switchStream(this.state.irisRtcStream, screenShareConfig);
+            this.state.irisRtcSession.switchStream(this.state.irisRtcStream, streamConfig);
           });
         })
         .catch((error) => console.error('ERROR: ' + error));

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -267,6 +267,7 @@ export default (ComposedComponent) => {
 
         // TODO: handler needs update
         this.state.irisRtcStream.onLocalStream = this._onLocalStream.bind(this);
+        this.state.irisRtcStream.irisVideoStreamStopped = this._onStreamStopped.bind(this)
 
         this.state.irisRtcSession.onRemoteStream = this._onRemoteStream.bind(this);
         this.state.irisRtcSession.onSessionCreated = this._onSessionCreated.bind(this);
@@ -411,6 +412,14 @@ export default (ComposedComponent) => {
         }
         this.eventEmitter.emitWebRTCEvent(WebRTCConstants.WEB_RTC_ON_LOCAL_VIDEO);
       });
+    }
+
+
+    _onStreamStopped() {
+      //this probably needs some checks. Because stop of stream doesn't
+      //necessarily imply that the screen share ended. Could've been something
+      //else.
+      this._endScreenshare()
     }
 
     _onRemoteStream(stream) {


### PR DESCRIPTION
Closed previous PR because my new commit didn't show up there. 

- Fixes to both calls of switchStream
- Log statements fixed so now they don't reference undefined objects/fields
- now when the user clicks the desktop button in the toolbar for the second time, screen share stops and the local videostream is restored

Everything appears to work well in the tab that shared screen. But the recipient tab ends up with two extra frozen horizontal boxes in the footer by the end of screen share. Murthy says this will be fixed in the JS SDK in the next release. 